### PR TITLE
Fix container users

### DIFF
--- a/inventory/host_vars/local.timeoverflow.org/config.yml
+++ b/inventory/host_vars/local.timeoverflow.org/config.yml
@@ -3,6 +3,9 @@ database_name: timeoverflow_development
 rails_environment: development
 
 sys_admins:
+  - name: timeoverflow
+    ssh_key: "~/.ssh/id_rsa.pub"
+    state: present
   - name: "{{ lookup('env', 'USER') }}"
     ssh_key: "~/.ssh/id_rsa.pub"
     state: present

--- a/scripts/create-container.sh
+++ b/scripts/create-container.sh
@@ -15,9 +15,9 @@ RETRIES=5
 echo "Creating config file: $LXC_CONFIG"
 cat > "$LXC_CONFIG" <<EOL
 # Network
-lxc.network.type = veth
-lxc.network.flags = up
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.flags = up
+lxc.net.0.link = lxcbr0
 
 # Volumes
 lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs/opt/$PROJECT_NAME none bind,create=dir 0.0

--- a/scripts/create-container.sh
+++ b/scripts/create-container.sh
@@ -42,7 +42,7 @@ if [ -z "${exist_container}" ] ; then
 fi
 echo "Container ready"
 
-# Check if container is running, if not start
+# Check if container is running, if not start it
 count=1
 while [ $count -lt $RETRIES ] && [ -z "$is_running" ]; do
   is_running=$(sudo lxc-ls --running --filter ^"$NAME"$)

--- a/scripts/create-container.sh
+++ b/scripts/create-container.sh
@@ -129,7 +129,7 @@ ansible-playbook playbooks/sys_admins.yml --limit=dev -u root
 echo "Very well! LXC container $NAME has been created and configured"
 echo
 echo "You should be able to access using:"
-echo "> ssh $USER@$HOST"
+echo "> ssh timeoverflow@$HOST"
 echo
 echo "To install all the dependencies run:"
 echo "> ansible-playbook playbooks/provision.yml --limit=dev"


### PR DESCRIPTION
The main issue here is that mounting a local path into a LXC container the directory and all its content will have the same permission `uid` and `gid` as in the host. This means that if in our host the project directory owner is the user with `1000` as `uid`, in the container the owner of that directory will be the user with the same `uid`, for instance `ubuntu` in the case of `uid=1000` in Ubuntu Xenial.

Due to this we'll need to ensure that the user that will have to modify the files in that directory from inside the container must have the same `uid` and `gid` as in the host.

In order to achieve this we create the `timeoverflow` user specifying `uid` and `gid`.