### PR TITLE
Fix staging IP

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -2,7 +2,7 @@
 local.timeoverflow.org
 
 [staging]
-staging.timeoverflow.org ansible_host=51.15.80.46
+staging.timeoverflow.org ansible_host=163.172.169.55
 
 [timeoverflow:children]
 dev


### PR DESCRIPTION
Scaleway doesn't allow you to re-use reserved IPs when you change data center location. We changed from Amsterdam to Paris because Scaleway's scarcity of servers offer.