### PR TITLE
Fix nginx configuration

### DIFF
--- a/roles/webserver/templates/timeoverflow.conf.j2
+++ b/roles/webserver/templates/timeoverflow.conf.j2
@@ -10,6 +10,11 @@ server {
     server_name {{ item.value.server_name }};
 
     location / {
+        proxy_set_header  Host                $host;
+        proxy_set_header  X-Real-IP           $remote_addr;
+        proxy_set_header  X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto   $scheme;
+        proxy_redirect    off;
         proxy_pass http://app_server;
     }
 }


### PR DESCRIPTION
The infamous redirect to `https://app_server` :trollface: 

Basically if you don't add `proxy_set_header  X-Forwarded-Proto   $scheme;` the protocol will change from `https` to `http` while proxying to the upstream. Since our upstream is a Rails app with `force_ssl: true` it will redirect to `https`... and Nginx will obscurely redirect to `https://app_server` 🤕 