### PR TITLE
dont use SSL on development

### DIFF
--- a/inventory/host_vars/local.timeoverflow.org/config.yml
+++ b/inventory/host_vars/local.timeoverflow.org/config.yml
@@ -16,3 +16,4 @@ developers: []
 
 nginx:
   server_name: "local.timeoverflow.org"
+  use_ssl: false

--- a/inventory/host_vars/staging.timeoverflow.org/config.yml
+++ b/inventory/host_vars/staging.timeoverflow.org/config.yml
@@ -20,3 +20,4 @@ developers:
 
 nginx:
   server_name: "staging.timeoverflow.org"
+  use_ssl: true

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -17,7 +17,7 @@
 
 # Only used in staging and production
 - import_tasks: letsencrypt.yml
-  when: rails_environment != "development"
+  when: nginx.use_ssl
 
 - include_role:
     name: vendor/jdauphant.nginx

--- a/roles/webserver/templates/timeoverflow.conf.j2
+++ b/roles/webserver/templates/timeoverflow.conf.j2
@@ -1,11 +1,16 @@
 # {{ ansible_managed }}
 server {
+    {% if nginx.use_ssl %}
     listen 443 ssl http2;
     listen [::]:443 ssl http2; # Listen on IPv6
     ssl_certificate /etc/letsencrypt/live/{{ item.value.server_name }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ item.value.server_name }}/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    {% else %}
+    listen 80 default_server;
+    listen [::]:80 default_server; # Listen on IPv6
+    {% endif %}
 
     server_name {{ item.value.server_name }};
 


### PR DESCRIPTION
Added `nginx.use_ssl` config var. It's used to import the letsencrypt task and in the nginx template ( to listen to the correct port ).