### PR TITLE
unfuck postgres

### DIFF
--- a/inventory/host_vars/local.timeoverflow.org/config.yml
+++ b/inventory/host_vars/local.timeoverflow.org/config.yml
@@ -1,6 +1,7 @@
 ---
 database_name: timeoverflow_development
 rails_environment: development
+database_role_attributes: SUPERUSER
 
 development_user: "{{ lookup('env', 'USER') }}"
 

--- a/inventory/host_vars/staging.timeoverflow.org/config.yml
+++ b/inventory/host_vars/staging.timeoverflow.org/config.yml
@@ -1,6 +1,7 @@
 ---
 database_name: timeoverflow_staging
 rails_environment: staging
+database_role_attributes: # Left empty
 
 sys_admins:
   - name: enrico

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -4,19 +4,26 @@
   vars:
     postgresql_hba_entries:
       - { type: local, database: all, user: postgres, auth_method: peer }
-      - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
-      - { type: local, database: "{{ database_name }}", user: "{{ database_user }}", auth_method: md5 }
+      - { type: local, database: all, user: "{{ database_user }}", auth_method: peer }
     postgresql_locales:
       - 'es_ES.UTF-8'
-    postgresql_databases:
-      - name: "{{ database_name }}"
-        lc_collate: 'es_ES.UTF-8'
-        lc_ctype: 'es_ES.UTF-8'
-        state: present
+
+- import_role:
+    name: geerlingguy.postgresql
+    tasks_from: users
+  vars:
     postgresql_users:
       - name: "{{ database_user }}"
-        password: "{{ database_password }}"
-        db: "{{ database_name }}"
-        state: present
+        role_attr_flags: "{{ database_role_attributes }}"
+
+- import_role:
+    name: geerlingguy.postgresql
+    tasks_from: databases
+  vars:
+    postgresql_databases:
+      - name: "{{ database_name }}"
+        owner: "{{ database_user }}"
+        lc_collate: 'es_ES.UTF-8'
+        lc_ctype: 'es_ES.UTF-8'
 
 - import_tasks: create_extensions.yml


### PR DESCRIPTION
# Wat

`bundle exec rake db:test:prepare` does not work on development, because of permission issues.

* `timeoverflow` role have SUPERUSER pawah on development
* password is removed, using `peer` authentication
* `timeoverflow_test` database should only be necessary on development actually

The following changes in `config/database.yml` are needed too: https://github.com/coopdevs/timeoverflow/pull/363