### PR TITLE
Fix LXC script

### DIFF
--- a/scripts/config/lxc.cfg
+++ b/scripts/config/lxc.cfg
@@ -1,7 +1,8 @@
 # Vars to use in lxc-create
 NAME="timeoverflow"
-TEMPLATE="/usr/share/lxc/templates/lxc-ubuntu"
+DISTRIBUTION="ubuntu"
 RELEASE="xenial"
+ARCH="amd64"
 LXC_CONFIG="/tmp/ubuntu.$NAME.conf"
 HOST="local.$NAME.org"
 PROJECT_NAME="timeoverflow"

--- a/scripts/create-container.sh
+++ b/scripts/create-container.sh
@@ -26,9 +26,9 @@ EOL
 # Print configuration
 echo "* CONFIGURATION:"
 echo "  - Name: $NAME"
-echo "  - Template: $TEMPLATE"
-echo "  - LXC Configuration: $LXC_CONFIG"
+echo "  - Distribution: $DISTRIBUTION"
 echo "  - Release: $RELEASE"
+echo "  - LXC Configuration: $LXC_CONFIG"
 echo "  - Host: $HOST"
 echo "  - Project Name: $PROJECT_NAME"
 echo "  - Project Directory: $PROJECT_PATH"
@@ -38,7 +38,7 @@ echo
 exist_container="$(sudo lxc-ls --filter ^"$NAME"$)"
 if [ -z "${exist_container}" ] ; then
   echo "Creating container $NAME"
-  sudo lxc-create --name "$NAME" -f "$LXC_CONFIG" -t "$TEMPLATE" -l INFO -- --release "$RELEASE"
+  sudo lxc-create --name "$NAME" -f "$LXC_CONFIG" -t download -l INFO -- --dist "$DISTRIBUTION" --release "$RELEASE" --arch "$ARCH"
 fi
 echo "Container ready"
 
@@ -120,6 +120,9 @@ sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /home/timeoverflow/.ss
 echo "Installing Python2.7 in container $NAME"
 sudo lxc-attach -n "$NAME" -- sudo apt update
 sudo lxc-attach -n "$NAME" -- sudo apt install -y python2.7
+
+# Install SSH server in container
+sudo lxc-attach -n "$NAME" -- sudo apt install -y openssh-server
 
 # System administrators
 echo "Adding user $USER as system administrator to $HOST"

--- a/scripts/create-container.sh
+++ b/scripts/create-container.sh
@@ -114,7 +114,7 @@ sudo lxc-attach -n "$NAME" -- /usr/sbin/useradd --uid "$project_uid" --gid "$pro
 
 # Add system user's SSH public key to `timeoverflow` user
 echo "Copying system user's SSH public key to 'timeoverflow' user in container"
-sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /home/timeoverflow/.ssh && echo $ssh_key > /home/timeoverflow/.ssh/authorized_keys"
+sudo lxc-attach -n "$NAME" -- sudo -u timeoverflow -- sh -c "/bin/mkdir -p /home/timeoverflow/.ssh && echo $ssh_key > /home/timeoverflow/.ssh/authorized_keys"
 
 # Install python2.7 in container
 echo "Installing Python2.7 in container $NAME"


### PR DESCRIPTION
### WAT
1. LXC 3.0 has been [released](https://discuss.linuxcontainers.org/t/lxc-3-0-0-has-been-released/1449) and `ubuntu` template is not included in the package anymore. The suggested template strategy is `download`.
2. @danypr92 discovered that we were creating `.ssh/` directory and its content with `root` user. This would make it impossible to create files like `.ssh/known_hosts` and so on.