### PR TITLE
Add Redis

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -21,3 +21,8 @@
     - role: webserver
       when: not development_environment
     - cacheserver
+    - role: DavidWittman.redis
+      vars:
+        redis_version: 4.0.9
+        redis_verify_checksum: true
+        redis_checksum: "sha256:df4f73bc318e2f9ffb2d169a922dec57ec7c73dd07bccf875695dbeecd5ec510"

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,3 +10,5 @@
   version: v2.13
 - src: coopdevs.certbot_nginx
   version: 0.0.1
+- src: DavidWittman.redis
+  version: 1.2.5


### PR DESCRIPTION
### WAT
We are going to implement a background jobs system:
https://github.com/mperham/sidekiq

The jobs will be stored in Redis.

### NOTES
Remember to comment out [PrivateDevices=yes](https://github.com/DavidWittman/ansible-redis/blob/master/templates/default/redis.service.j2#L23) from the redis systemd unit to be able to start it in a LXC container (development environment). Otherwise you'll get the following error:
https://gist.github.com/enricostano/0ec1aa0cb9636f1e479ef0615c60db82#file-systemd_journal-L7
We'll try to find a better solution ASAP.

EDIT: my prayers have been listened :joy: https://github.com/systemd/systemd/pull/8417#issuecomment-388161696