### PR TITLE
Add Sidekiq systemd unit

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -26,4 +26,5 @@
         redis_version: 4.0.9
         redis_verify_checksum: true
         redis_checksum: "sha256:df4f73bc318e2f9ffb2d169a922dec57ec7c73dd07bccf875695dbeecd5ec510"
+        redis_as_service: false # Read NOTES in https://github.com/coopdevs/timeoverflow-provisioning/pull/47
     - role: background_jobs

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -26,3 +26,4 @@
         redis_version: 4.0.9
         redis_verify_checksum: true
         redis_checksum: "sha256:df4f73bc318e2f9ffb2d169a922dec57ec7c73dd07bccf875695dbeecd5ec510"
+    - role: background_jobs

--- a/roles/background_jobs/tasks/main.yml
+++ b/roles/background_jobs/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+# TODO: Remove this once https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1770481
+#       get solved and backported
+- name: create redis systemd service
+  template:
+    src: redis_service.j2
+    dest: /etc/systemd/system/redis_6379.service
+    mode: 0644
+
+# TODO: Remove this once https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1770481
+#       get solved and backported
+- name: set redis to start at boot
+  service:
+    name: redis_6379
+    enabled: yes
+
 - name: Create systemd unit for Sidekiq
   template:
     src: sidekiq_service.j2

--- a/roles/background_jobs/tasks/main.yml
+++ b/roles/background_jobs/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Create systemd unit for Sidekiq
+  template:
+    src: sidekiq_service.j2
+    dest: /etc/systemd/system/sidekiq.service
+    mode: 0644
+
+- name: Set Sidekiq to start at boot
+  service:
+    name: sidekiq
+    enabled: yes

--- a/roles/background_jobs/templates/redis_service.j2
+++ b/roles/background_jobs/templates/redis_service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=Advanced key-value store
+After=network.target
+Documentation=http://redis.io/documentation, man:redis-server(1)
+
+[Service]
+Type=forking
+ExecStart=/opt/redis/bin/redis-server /etc/redis/6379.conf
+EnvironmentFile=-/etc/default/redis_6379
+PIDFile=/var/run/redis/6379.pid
+TimeoutStopSec=0
+Restart=always
+User=redis
+Group=redis
+
+UMask=007
+PrivateTmp=yes
+LimitNOFILE=16384
+ProtectHome=yes
+ReadOnlyDirectories=/
+ReadWriteDirectories=-/var/lib/redis/6379
+ReadWriteDirectories=-/var/run/redis
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+
+# redis-server writes its own config file when in cluster mode so we allow
+# writing there (NB. ProtectSystem=true over ProtectSystem=full)
+ProtectSystem=true
+ReadWriteDirectories=-/etc/redis
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/background_jobs/templates/sidekiq_service.j2
+++ b/roles/background_jobs/templates/sidekiq_service.j2
@@ -1,0 +1,30 @@
+# Inspired by https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service
+#
+[Unit]
+Description=sidekiq
+# start us only once the network and logging subsystems are available,
+# consider adding redis-server.service if Redis is local and systemd-managed.
+After=syslog.target network.target redis_6379.service
+
+[Service]
+Type=simple
+WorkingDirectory=/var/www/timeoverflow/current
+EnvironmentFile=-/etc/default/timeoverflow
+ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec sidekiq -e {{ rails_environment }}
+User=timeoverflow
+Group=timeoverflow
+UMask=0002
+
+# Greatly reduce Ruby memory fragmentation and heap usage
+# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
+Environment=MALLOC_ARENA_MAX=2
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=sidekiq
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/common/templates/sudoers.timeoverflow
+++ b/roles/common/templates/sudoers.timeoverflow
@@ -2,3 +2,7 @@ timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl start timeoverflow
 timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl stop timeoverflow
 timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl restart timeoverflow
 timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl reload timeoverflow
+timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl start sidekiq
+timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl stop sidekiq
+timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl restart sidekiq
+timeoverflow ALL=(ALL) NOPASSWD: /bin/systemctl reload sidekiq


### PR DESCRIPTION
### WAT
We need to manage Sidekiq as we do for all others services.

### Notes
It also includes a fix for a bug in systemd that will be backported to `16.04` and `18.04` in the future.