### PR TITLE
Upgrade Ansible role certbot_nginx

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,6 +9,6 @@
 - src: jdauphant.nginx
   version: v2.21.2
 - src: coopdevs.certbot_nginx
-  version: 0.0.1
+  version: 0.0.3
 - src: DavidWittman.redis
   version: 1.2.5


### PR DESCRIPTION
Basically to address https://community.letsencrypt.org/t/how-to-stop-using-tls-sni-01-with-certbot/83210
we needed `certbot` version to be at `0.28`.