### PR TITLE
import_role vs include_role

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include_role:
+- import_role:
     name: vendor/geerlingguy.postgresql
   vars:
     postgresql_hba_entries:
@@ -8,16 +8,16 @@
     postgresql_locales:
       - 'es_ES.UTF-8'
 
-- import_role:
-    name: geerlingguy.postgresql
+- include_role:
+    name: vendor/geerlingguy.postgresql
     tasks_from: users
   vars:
     postgresql_users:
       - name: "{{ database_user }}"
         role_attr_flags: "{{ database_role_attributes }}"
 
-- import_role:
-    name: geerlingguy.postgresql
+- include_role:
+    name: vendor/geerlingguy.postgresql
     tasks_from: databases
   vars:
     postgresql_databases:


### PR DESCRIPTION
Fix #57 

Much better solution compared to https://github.com/coopdevs/timeoverflow-provisioning/pull/56 :trollface: 

From the [doc](https://docs.ansible.com/ansible/2.4/playbooks_reuse_includes.html#includes-vs-imports):

> All import* statements are pre-processed at the time playbooks are parsed.
> All include* statements are processed as they encountered during the execution of the playbook.

Being pre-processed at parse time, the `postgresql_databases` variable was getting populated too early.
