### PR TITLE
Ansible import vs include strikes back

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include_role:
+- import_role:
     name: vendor/geerlingguy.postgresql
   vars:
     postgresql_hba_entries:
@@ -8,7 +8,7 @@
     postgresql_locales:
       - 'es_ES.UTF-8'
 
-- import_role:
+- include_role:
     name: geerlingguy.postgresql
     tasks_from: users
   vars:
@@ -16,7 +16,7 @@
       - name: "{{ database_user }}"
         role_attr_flags: "{{ database_role_attributes }}"
 
-- import_role:
+- include_role:
     name: geerlingguy.postgresql
     tasks_from: databases
   vars:


### PR DESCRIPTION
From the [doc](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_includes.html#includes-vs-imports):

>    All import* statements are pre-processed at the time playbooks are parsed.
>    All include* statements are processed as they are encountered during the execution of the playbook.

Basically users and db variables were parsed and set while running the main role :boom: 