### PR TITLE
remove chromedriver

### DIFF
--- a/roles/common/tasks/install_packages.yml
+++ b/roles/common/tasks/install_packages.yml
@@ -23,9 +23,4 @@
     state: present
   when: rails_environment == "development"
 
-- name: Symlink chromedriver globally
-  file:
-    path: /usr/bin/chromedriver
-    src: /usr/lib/chromium-browser/chromedriver
-    state: link
-  when: rails_environment == "development"
+


### PR DESCRIPTION
As [reported by Jordi in community](https://community.coopdevs.org/t/error-a-lintentar-instalar-timeoverflow-en-local/935) you can't [Build development environment](https://github.com/coopdevs/timeoverflow/wiki/Build-development-environment-with-LXC-for-GNU-Linux) on

`ansible-playbook playbooks/provision.yml --limit=dev
`
return error:

```
TASK [common : Symlink chromedriver globally] **********************************
fatal: [local.timeoverflow.org]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0755", "msg": "refusing to convert from file to symlink for /usr/bin/chromedriver", "owner": "root", "path": "/usr/bin/chromedriver", "size": 12375944, "state": "file", "uid": 0}
```


If I remove chrome driver from [roles/common/tasks/install_packages.yml](https://github.com/coopdevs/timeoverflow-provisioning/compare/fix/remove-chromedriver?expand=1#diff-fe93ab603f374e45926efd8a80d64a84) and everything works fine. 

I don't know what chromedriver do, maybe this problem is related with https://github.com/coopdevs/timeoverflow/commit/271a5be3b93a3fa8970e8d9b6572c1c8a1a56d6b