### PR TITLE
Set up Travis CI to lint the code on push

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+exclude_paths:
+  - vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+---
+sudo: required
+dist: bionic
+language: python
+python: "3.7.4"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - ansible-lint playbooks/*.yml --exclude vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - ansible-lint playbooks/*.yml --exclude vendor/
+  - ansible-lint playbooks/*.yml
   - yamllint **/*.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ install:
 
 script:
   - ansible-lint playbooks/*.yml --exclude vendor/
+  - yamllint **/*.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,23 @@
+---
+# Based on ansible-lint config
+extends: default
+
+ignore: vendor/
+
+rules:
+  braces: {max-spaces-inside: 1, level: error}
+  brackets: {max-spaces-inside: 1, level: error}
+  colons: {max-spaces-after: -1, level: error}
+  commas: {max-spaces-after: -1, level: error}
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: {max: 3, level: error}
+  hyphens: {level: error}
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: {type: unix}
+  trailing-spaces: disable
+  truthy: disable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible==2.8.5
+ansible-lint==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible==2.8.5
 ansible-lint==4.1.0
+yamllint==1.17.0

--- a/roles/common/tasks/groups.yml
+++ b/roles/common/tasks/groups.yml
@@ -1,4 +1,5 @@
 ---
-- group:
+- name: Create 'timeoverflow' group
+  group:
     name: timeoverflow
     state: present

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -13,7 +13,7 @@
     minute: 0
     state: present
     job: >
-      /bin/bash -l -c 'cd /var/www/timeoverflow/current && bin/rails runner -e production '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1'
+      /bin/bash -l -c 'cd /var/www/timeoverflow/current && bin/rails runner -e production '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1' # noqa 204
 
 - include_role:
     name: vendor/coopdevs.certbot_nginx


### PR DESCRIPTION
This is just a first step towards having a decent continuous integration. Now that we'll be touching this repo a lot it's important to ensure a healthy state in `master`. 

For now, we only lint both ansible and yaml, which is better than nothing. In an upcoming PR, I want to explore also provisioning the Travis box as we did in https://github.com/openfoodfoundation/ofn-install. That's going to effectively protect us against regressions.