### PR TITLE
Replace redis role with geerlingguy's

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -29,11 +29,5 @@
     - role: webserver
       when: not development_environment
     - role: cacheserver
-    - role: DavidWittman.redis
-      vars:
-        redis_version: 4.0.9
-        redis_verify_checksum: true
-        redis_checksum: "sha256:df4f73bc318e2f9ffb2d169a922dec57ec7c73dd07bccf875695dbeecd5ec510"
-        redis_as_service: false # Read NOTES in https://github.com/coopdevs/timeoverflow-provisioning/pull/47
-        redis_bind: 127.0.0.1
+    - role: geerlingguy.redis
     - role: background_jobs

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,5 +10,5 @@
   version: v2.21.2
 - src: coopdevs.certbot_nginx
   version: 0.0.4
-- src: DavidWittman.redis
-  version: 1.2.5
+- src: geerlingguy.redis
+  version: 1.6.0

--- a/roles/background_jobs/tasks/main.yml
+++ b/roles/background_jobs/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-# TODO: Remove this once https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1770481
-#       get solved and backported
-- name: create redis systemd service
-  template:
-    src: redis_service.j2
-    dest: /etc/systemd/system/redis_6379.service
-    mode: 0644
-
-# TODO: Remove this once https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1770481
-#       get solved and backported
-- name: set redis to start at boot
-  service:
-    name: redis_6379
-    enabled: yes
-
 - name: Create systemd unit for Sidekiq
   template:
     src: sidekiq_service.j2


### PR DESCRIPTION
The role we used fails while provisioning the dev env with "Read only file system" when reloading sysctl. See the role's task: https://github.com/DavidWittman/ansible-redis/blob/98bef17f323438dec378527e459e7fd72d27e31f/tasks/install.yml#L2-L9

We might see an error as mentioned in https://github.com/geerlingguy/ansible-role-redis/pull/13 but that is something we can then fix ourselves. Let's hope we don't have to.