### PR TITLE
Revert "Merge pull request #62 from coopdevs/feature/switch-from-elas…

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -41,6 +41,9 @@
             lc_collate: 'es_ES.UTF-8'
             lc_ctype: 'es_ES.UTF-8'
         postgresql_python_library: python3-psycopg2 # related to ansible_python_interpreter
+    - role: vendor/elastic.elasticsearch
+      es_instance_name: timeoverflow
+      es_heap_size: "512m"
     - role: webserver
       when: not development_environment
     - role: cacheserver

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,6 +6,8 @@
   version: 3.4.3
 - src: geerlingguy.postgresql
   version: 2.0.0
+- src: elastic.elasticsearch
+  version: 5.5.1
 - src: jdauphant.nginx
   version: v2.21.2
 - src: coopdevs.certbot_nginx


### PR DESCRIPTION
…tic-to-pg-search"

This reverts commit 14046a433e9113ddb3a81843c42da64e6cfc10c7, reversing changes made to ec75496ae21424ea2a1e6ee764ed40a9bb0353ab.

This undoes https://github.com/coopdevs/timeoverflow-provisioning/pull/62/ so we can set up a new production server without having to include the PostgreSQL text search yet.