### PR TITLE
Install postgresql-contrib package as well

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -23,6 +23,7 @@
   apt:
     name:
       - postgresql-9.4
+      - postgresql-contrib-9.4
       - libpq-dev
       - python3-psycopg2
 


### PR DESCRIPTION
Closes https://github.com/coopdevs/timeoverflow-provisioning/issues/88

This will provide the extensions the app relies on such as hstore.