### PR TITLE
Run provisioning in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ install:
 script:
   - ansible-lint playbooks/*.yml
   - yamllint **/*.yml
+  - sudo apt remove --purge postgresql-9.* postgresql-10
+  - sudo rm -rf /etc/postgresql/9.4/ /var/lib/postgresql/9.4/
+  - sudo apt-get update
+  - ansible-galaxy install -r requirements.yml
+  - ansible-playbook playbooks/sys_admins.yml --limit=travis_ci
+  - ansible-playbook playbooks/provision.yml --limit=travis_ci

--- a/inventory/host_vars/travis_ci/config.yml
+++ b/inventory/host_vars/travis_ci/config.yml
@@ -1,0 +1,21 @@
+---
+database_name: timeoverflow_development
+rails_environment: development
+database_role_attributes: SUPERUSER
+
+development_user: "{{ lookup('env', 'USER') }}"
+
+sys_admins:
+  - name: timeoverflow
+    ssh_key: "../pub_keys/pau.pub"
+    state: present
+
+developers: []
+
+# Set 'development_environment' to "true" to skip SSL and nginx tasks
+development_environment: true
+
+# Set super admins email addresses
+superadmins: 'admin@timeoverflow.org'
+
+backups_role_enabled: false

--- a/inventory/host_vars/travis_ci/secrets.yml
+++ b/inventory/host_vars/travis_ci/secrets.yml
@@ -1,0 +1,4 @@
+---
+  database_password: OZM+Ey389Rk=
+  mailer_sender: info@timeoverflow.org
+  secret_token: 9JlwmB955Q24nH6mLhVlHDCy/7ju/rPgTXAn8TgPDoQyPOyLWmNqR5758lh/DUVDBPcOnpJlkYwFbXxvHr2hBBjsLhivNSX79uwG44cDIhfJBoQSYP5jlsmBWVrAF/oH+1d/0EArVjlTU6bdynhO4bbIlPIdPzABycsLI43wUj8=

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -11,3 +11,7 @@ staging18.timeoverflow.org ansible_host=116.203.236.102
 dev
 staging
 staging18
+ci
+
+[ci]
+travis_ci ansible_connection=local

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -33,6 +33,7 @@
     contype: local
     databases: all
     method: peer
+    create: true
 
 - name: Add user
   become: yes

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -33,7 +33,6 @@
     contype: local
     databases: all
     method: peer
-    create: true
 
 - name: Add user
   become: yes


### PR DESCRIPTION
The cost-effective solution we came with to have continuous integration for our provisioning scripts works as follows:

* Executes Ansible using a local connection, modifying the same CI container
it's running on.
* Because of that, it removes any installed PostgreSQL versions. This
way, we ensure our own database role works.

Also, we had to manually remove PostgreSQL cluster directories. The `--purge` apt's argument doesn't seem to do it. I tried on a LXC and running `sudo apt remove --purge postgresql-9.4` opens a ncurses-like UI to confirm the actual purge of cluster directories. I guess this is what we can't do when executing it in CI.

Finally, we add an argument to create pg_hba.conf file if it doesn't exist. It was necessary to make the job succeed.