### PR TITLE
Install the Hstore PostgreSQL extension

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -52,3 +52,10 @@
     lc_ctype: 'es_ES.UTF-8'
     encoding: 'UTF-8'
     template: 'template0'
+
+- name: Adds Hstore extension to the database
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: hstore
+    db: "{{ database_name }}"


### PR DESCRIPTION
We do it with Ansible with the `postgres` user so we don't need to add
`SUPERUSER` permissions to the app's DB user. Something we don't like.

Then, when deploying the app the extensions listed in `db/schema.rb` are
already in place and the `rake db:migrate` or `rake db:setup` succeeds.