### PR TITLE
Parallelize linting in CI with stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,17 @@ dist: bionic
 language: python
 python: 3.7.4
 
-install:
-  - pip install -r requirements.txt
-
-script:
-  - ansible-lint playbooks/*.yml
-  - yamllint **/*.yml
-  - ansible-galaxy install -r requirements.yml
-  - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=ci_server
-  - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=ci_server
+jobs:
+  include:
+    - stage: lint
+      script: ansible-lint playbooks/*.yml
+    - stage: lint
+      script: yamllint **/*.yml
+    - stage: provision
+      script:
+        - ansible-galaxy install -r requirements.yml
+        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=ci_server
+        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=ci_server
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,11 @@ jobs:
       script: yamllint **/*.yml
     - stage: provision
       script:
+        - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv
+          -in travis.enc -out travis -d
+        - eval "$(ssh-agent -s)"
+        - chmod 600 travis
+        - ssh-add travis
         - ansible-galaxy install -r requirements.yml
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=ci_server
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=ci_server
-
-before_install:
-  - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv
-    -in travis.enc -out travis -d
-  - eval "$(ssh-agent -s)"
-  - chmod 600 travis
-  - ssh-add travis


### PR DESCRIPTION
This also removes the useless `install` step because according to
https://docs.travis-ci.com/user/languages/python we are running the
default command.

Besides, running into two different stages will give visibility to the
steps of the build. It's hard to know when the linting failed due to the
long output the provisioning generates.

much better now. Otherwise, you just get a bunch of output and exit statuses.

![Screenshot from 2019-10-21 20-56-27](https://user-images.githubusercontent.com/762088/67234390-55263980-f445-11e9-8e46-bb16dfb6b08c.png)
