### PR TITLE
Skip provisioning CI when building master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       script: ansible-lint playbooks/*.yml
     - stage: lint
       script: yamllint **/*.yml
-    - stage: provision
+    - stage: provision_ci
       script:
         - eval "$(ssh-agent -s)"
         - chmod 600 travis
@@ -26,6 +26,8 @@ jobs:
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=staging --vault-password-file vault_pass
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=staging --vault-password-file vault_pass
 stages:
+  - name: provision_ci
+    if: branch != master
   - name: provision_staging
     if: type = push AND branch = master
 before_install:


### PR DESCRIPTION
When building from the master branch we want to provision staging but provisioning the CI server is totally unnecessary and, as it is, it could create concurrency problems if another PR is being built. It
happened to me that two different CI builds were fighting for the dpkg lock and one failed.