### PR TITLE
Cache ansible galaxy roles in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ dist: bionic
 language: python
 python: 3.7.4
 
+cache:
+  directories:
+    - vendor
+
 jobs:
   include:
     - stage: lint


### PR DESCRIPTION
This should considerably speed up CI builds and we rarely touch add or remove vendor roles. If that was the case, Travis will store any modifications in the cache. I guessed that from docs and a PR:

> Only modifications made to the cached directories from normal pushes are stored.

source: https://docs.travis-ci.com/user/caching

> If nothing in the dist directory changed during the build, nothing new will be uploaded.

source: https://github.com/travis-ci/travis-ci/issues/9814#issuecomment-433669814