### PR TITLE
Do not restart ES until our unit is in place

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -8,6 +8,8 @@
     es_version: 2.4.6
     es_use_repository: false
     es_allow_downgrades: true
+    es_restart_on_change: false
+    es_start_service: false
 
 - name: Override ElasticSearch's Systemd unit
   template: src=elasticsearch.j2 dest={{ instance_sysd_script }} mode=0644 force=yes


### PR DESCRIPTION
Currently the elastic.elasticsearch role tries to restart Elastic Search
with a system unit that doesn't support the version we're installing
which is 2.4.6. As a result, systemd fails at restarting it and the
"Wait for elasticsearch to startup" Ansible times out.

That's something we don't need since in our wrapper role roles/elasticsearch/
we override the unit with the appropriate ElasticSearch arguments (their
names changed in recent versions) and restart the service.

By digging into the role's code I realized these changed variables are
the ones that control the restart:

```yml
- name: restart elasticsearch
  service: name={{instance_init_script | basename}} state=restarted enabled=yes
  when:
    - es_restart_on_change
    - es_start_service
  register: es_restarted
```