### PR TITLE
Cache pip packages in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 python: 3.7.4
 
 cache:
+  pip: true
   directories:
     - vendor
 


### PR DESCRIPTION
This should speed the CI builds a bit more. Also, we don't change the requirements.txt often.