### PR TITLE
Migrate production database to a new prod. server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vagrant/
 vendor/
 .vault_pass
+**/*.dump

--- a/README.md
+++ b/README.md
@@ -114,3 +114,23 @@ Now it's all setup. If you push, Travis should be able to provision the CI serve
 ## Staging Provision
 
 We also configured our pipeline to provision staging when merging into master.  This way we skip the manual step and staging will always be in sync with master so we can test things in a production-like environment.
+
+## Database migration
+
+We added support for migrating the database to a new production server by means of a dump and a restore. It's implemented in two different playbooks, backup.yml and restore.yml.
+
+First, run the following command against the server you want to migrate from:
+
+```
+$ pyenv exec ansible-playbook playbooks/backup.yml --limit <source_server> --vault-password-file=.vault_pass
+```
+
+This will store the backup file as something like `playbooks/files/timeoverflow_staging-2019-11-18-15:43:01.dump` in your machine. Then, run the following to restore in another server:
+
+```
+$ pyenv exec ansible-playbook playbooks/restore.yml --limit <target_server> -e "backup_file=timeoverflow_staging-2019-11-18-15:37:15.sql.gz" --vault-password-file=.vault_pass
+```
+
+Note the `backup_file` you specify must be the basename of the file that the `playbooks/backup.yml` downloaded to your `playbooks/files/` directory. Keep in mind you won't see it if you `git status` since it's ignored by Git.
+
+To migrate the old production database you'll have to specify `source_server` as `old_production`, while `target_server` can be `staging` to test things first and the new production host when ready.

--- a/inventory/host_vars/staging.timeoverflow.org/database_migration.yml
+++ b/inventory/host_vars/staging.timeoverflow.org/database_migration.yml
@@ -1,0 +1,3 @@
+---
+# Database migration settings
+source_db: "{{ database_name }}"

--- a/inventory/host_vars/timeoverflow.local/database_migration.yml
+++ b/inventory/host_vars/timeoverflow.local/database_migration.yml
@@ -1,0 +1,3 @@
+---
+# Database migration settings
+source_db: "{{ database_name }}"

--- a/inventory/host_vars/www.timeoverflow.org/database_migration.yml
+++ b/inventory/host_vars/www.timeoverflow.org/database_migration.yml
@@ -1,0 +1,4 @@
+---
+# Database migration settings
+source_db: timeoverflow_production
+ansible_python_interpreter: /usr/bin/python

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -7,11 +7,15 @@ staging.timeoverflow.org ansible_host=116.203.113.233
 [staging18]
 staging18.timeoverflow.org ansible_host=116.203.236.102
 
+[old_production]
+www.timeoverflow.org
+
 [timeoverflow:children]
 dev
 staging
 staging18
 ci
+old_production
 
 [ci]
 ci_server ansible_host=78.46.195.94

--- a/playbooks/backup.yml
+++ b/playbooks/backup.yml
@@ -1,0 +1,32 @@
+# Creates and downloads a database dump from the server you specify with
+# --limit. You can then restore it using playbooks/restore.yml. Check out the
+# README for more details.
+#
+# Usage:
+#
+#   $ pyenv exec ansible-playbook playbooks/backup.yml
+#     --limit <source_server>
+#     --vault-password-file=.vault_pass
+---
+- hosts: timeoverflow
+  vars:
+    basename: "{{ source_db }}-{{ now }}.dump"
+    filename: "/tmp/{{ basename }}"
+
+  tasks:
+    - name: store current timestamp
+      set_fact:
+        now: "{{ lookup('pipe', 'date +%F-%T') }}"
+
+    - name: Dump database to a file
+      postgresql_db:
+        login_user: timeoverflow
+        name: "{{ source_db }}"
+        state: dump
+        target: "{{ filename }}"
+
+    - name: Copy dump to control host
+      fetch:
+        src: "{{ filename }}"
+        dest: "files/{{ basename }}"
+        flat: yes

--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -1,0 +1,47 @@
+# This requires you to run the playbooks/backup.yml first. Check that playbook
+# and the README for more details.
+#
+# Usage:
+#
+#   $ pyenv exec ansible-playbook playbooks/restore.yml
+#       --limit <target_server>
+#       -e "backup_file=timeoverflow_staging-2019-11-18-15:37:15.sql.gz"
+#       --vault-password-file=.vault_pass
+---
+- hosts: timeoverflow
+  vars:
+    filename: "/tmp/{{ backup_file }}"
+    target_db: "{{ database_name }}"
+  tasks:
+    - name: Copy dump to remote server
+      become: yes
+      copy:
+        src: "{{ backup_file }}"
+        dest: "/tmp/{{ backup_file }}"
+        owner: timeoverflow
+        group: timeoverflow
+        mode: '0644'
+
+    - name: Create db
+      become: yes
+      become_user: postgres
+      postgresql_db:
+        name: "{{ target_db }}"
+        owner: "{{ database_user }}"
+        lc_collate: 'es_ES.UTF-8'
+        lc_ctype: 'es_ES.UTF-8'
+        encoding: 'UTF-8'
+        template: 'template0'
+
+    - name: Restore database
+      become: yes
+      become_user: postgres
+      postgresql_db:
+        name: "{{ target_db }}"
+        owner: "{{ database_user }}"
+        lc_collate: 'es_ES.UTF-8'
+        lc_ctype: 'es_ES.UTF-8'
+        encoding: 'UTF-8'
+        template: 'template0'
+        target: "{{ filename }}"
+        state: restore


### PR DESCRIPTION
## Description

I added support for migrating the database to a new production server by means of a dump and a restore. It's implemented in two different playbooks, backup.yml and restore.yml.

First, run the following command against the server you want to migrate from:

```
$ pyenv exec ansible-playbook playbooks/backup.yml --limit <source_server>
```

This will store the backup file as something like `playbooks/timeoverflow_staging-2019-11-18-15:43:01.sql.gz` in your machine. Then, run the following to restore in another server:

```
$ pyenv exec ansible-playbook playbooks/restore.yml --limit <target_server> -e "backup_file=timeoverflow_staging-2019-11-18-15:37:15.sql.gz"
```

Note the `backup_file` you specify must be the basename of the file that the `playbooks/backup.yml` downloaded to your `playbooks/` directory. Keep in mind you won't see it if you `git status` since it's ignored by Git.

To migrate the old production database you'll have to specify `source_server` as `old_production`, while `target_server` can be `staging` to test things first and the new production host when ready.

## Still missing

- [x] Successfully restore a production backup in staging. The resulting database is empty :thinking: 
- [x] Successfully create the backup file when pointing to `old_production`. Still, when loging in as `timeoverflow` and running `pg_dump -Fc timeoverflow_production > /tmp/db.dump` does work.

For the record, this is the output I get.

```
TASK [Dump database to a file with compression] ***************************************************************************
 [WARNING]: Using world-readable permissions for temporary files Ansible needs to create when becoming an unprivileged
user. This may be insecure. For information on securing this, see https://docs.ansible.com/ansible/become.html#becoming-
an-unprivileged-user

fatal: [www.timeoverflow.org]: FAILED! => {"msg": "Missing sudo password"}
```

It seems like we'll have to run `playbooks/sys_admins.yml` against `old_production`. Any thoughts @danypr92 ?