### PR TITLE
Provision production from CI when staging passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ jobs:
       script: yamllint **/*.yml
     - stage: provision_ci
       script:
+        - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv -in encrypted_files.tar.enc -out encrypted_files.tar -d
+        - tar xvf encrypted_files.tar
         - eval "$(ssh-agent -s)"
         - chmod 600 travis
         - ssh-add travis
@@ -24,17 +26,28 @@ jobs:
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=ci_server
     - stage: provision_staging
       script:
+        - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv -in encrypted_files.tar.enc -out encrypted_files.tar -d
+        - tar xvf encrypted_files.tar
         - eval "$(ssh-agent -s)"
         - chmod 600 travis
         - ssh-add travis
         - ansible-galaxy install -r requirements.yml
-        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=staging --vault-password-file vault_pass
-        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=staging --vault-password-file vault_pass
+        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=staging --vault-password-file=vault_pass
+        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=staging --vault-password-file=vault_pass
+    - stage: provision_production
+      script:
+        - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv -in encrypted_files.tar.enc -out encrypted_files.tar -d
+        - tar xvf encrypted_files.tar
+        - eval "$(ssh-agent -s)"
+        - chmod 600 travis
+        - ssh-add travis
+        - ansible-galaxy install -r requirements.yml
+        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=production --vault-password-file=vault_pass
+        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=production --vault-password-file=vault_pass
 stages:
   - name: provision_ci
     if: branch != master
   - name: provision_staging
     if: type = push AND branch = master
-before_install:
-  - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv -in encrypted_files.tar.enc -out encrypted_files.tar -d
-  - tar xvf encrypted_files.tar
+  - name: provision_production
+    if: type = push AND branch = master


### PR DESCRIPTION
This will be useful now that we want to setup a new production server
quickly. Every PR we merged will be provisioned there only if it
succeeds in staging so we don't forget about keeping it up-to-date as we
move forward.

This will be removed once that machine is fully set up right before we
promote it to become the actual production server.

Note this points to a `production` host that doesn't exist yet. I'll
open a PR to update the inventory which will kick off the process.