### PR TITLE
Disable backups in staging

### DIFF
--- a/inventory/host_vars/staging.timeoverflow.org/config.yml
+++ b/inventory/host_vars/staging.timeoverflow.org/config.yml
@@ -38,4 +38,4 @@ superadmins: 'admin@timeoverflow.org'
 certificate_authority_email: "info@coopdevs.org"
 
 # Enable backups
-backups_role_enabled: true
+backups_role_enabled: false


### PR DESCRIPTION
We enabled it when trying out the new backups system but we don't need it anymore.