### PR TITLE
Add script used to rebuild a Hetzner server

### DIFF
--- a/rebuild
+++ b/rebuild
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo 'Rebuilding with ubuntu-18.04'
+
+hcloud server rebuild --image ubuntu-18.04 CI
+
+ssh-keygen -f "/home/pau/.ssh/known_hosts" -R "78.46.195.94"
+ssh -q root@78.46.195.94 exit 0
+
+pyenv exec ansible-playbook playbooks/sys_admins.yml --limit=ci_server -u root


### PR DESCRIPTION
I had this untracked file for a while and it annoys me in every commit.
It's the file I used a few times to rebuild a server when setting up
staging. It help when the server was doing nasty things as well as
recovering from a broken provisioning.

However, since https://github.com/coopdevs/donalo/pull/12 we now know
there's a better way to manage the state of a Hetzner server.