### PR TITLE
Add unicorn stop and db drop to restore a backup

### DIFF
--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -22,7 +22,27 @@
         group: timeoverflow
         mode: '0644'
 
-    - name: Create db
+    - name: Stop app server to kill database connections
+      become: yes
+      become_user: root
+      service:
+        name: timeoverflow
+        state: stopped
+
+    - pause: # noqa 502
+        prompt: "\n   => ⚡ Warning, harmful action ahead. Are you sure you want to drop the target database `{{ database_name }}`? (yes/no)"
+      register: drop_confirmation
+      delegate_to: localhost
+
+    - name: Drop target database
+      become: yes
+      become_user: postgres
+      postgresql_db:
+        name: "{{ target_db }}"
+        state: absent
+      when: drop_confirmation.user_input | bool
+
+    - name: Create target database
       become: yes
       become_user: postgres
       postgresql_db:
@@ -33,7 +53,7 @@
         encoding: 'UTF-8'
         template: 'template0'
 
-    - name: Restore database
+    - name: Restore database backup
       become: yes
       become_user: postgres
       postgresql_db:
@@ -45,3 +65,10 @@
         template: 'template0'
         target: "{{ filename }}"
         state: restore
+
+    - name: Start app server
+      become: yes
+      become_user: root
+      service:
+        name: timeoverflow
+        state: started


### PR DESCRIPTION
This steps provided necessary to properly restore a production backup in
next. First, we need to kill the existing database connections and then,
drop the existing database so we don't cause data inconsistencies
current and new records.

We did so with a user prompt to double check your pointing to the right
database.