### PR TITLE
Configure links in emails to point to their env

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -3,7 +3,7 @@ DATABASE_NAME={{ database_name }}
 DATABASE_USER={{ database_user }}
 DATABASE_PASSWORD={{ database_password }}
 SECRET_TOKEN={{ secret_token }}
-MAIL_LINK_HOST=www.timeoverflow.org
+MAIL_LINK_HOST={{ inventory_hostname }}
 MAILER_SENDER={{ mailer_sender }}
 {% if skylight_authentication is defined %}
 SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}


### PR DESCRIPTION
If we receive an email from next.timeoverflow.org we want it to point to
that same subdomain rather than production. The same for staging. This
is one of those little things that make our every day life harder and it
has a simple fix!