### PR TITLE
Dry paths with app_path and current_path vars

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -5,6 +5,8 @@ ansible_python_interpreter: /usr/bin/python3
 database_user: timeoverflow
 
 app_path: "/var/www/timeoverflow"
+current_path: "{{ app_path }}/current"
+
 # Backups vars
 backups_role_postgresql_enabled: true
 backups_role_sudoers_enabled: true

--- a/roles/background_jobs/templates/sidekiq_service.j2
+++ b/roles/background_jobs/templates/sidekiq_service.j2
@@ -8,7 +8,7 @@ After=syslog.target network.target redis_6379.service
 
 [Service]
 Type=simple
-WorkingDirectory=/var/www/timeoverflow/current
+WorkingDirectory={{ current_path }}
 EnvironmentFile=-/etc/default/timeoverflow
 ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec sidekiq -e {{ rails_environment }}
 User=timeoverflow

--- a/roles/common/tasks/directories.yml
+++ b/roles/common/tasks/directories.yml
@@ -1,15 +1,7 @@
 ---
-- name: "Create /var/www directory"
+- name: "Create {{ app_path }} directory"
   file:
-    path: "/var/www"
-    owner: root
-    group: root
-    mode: 0755
-    state: directory
-
-- name: "Create /var/www/timeoverflow directory"
-  file:
-    path: "/var/www/timeoverflow"
+    path: "{{ app_path }}"
     owner: timeoverflow
     group: timeoverflow
     mode: 02775

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -13,7 +13,7 @@
     minute: 0
     state: present
     job: >
-      /bin/bash -l -c 'cd /var/www/timeoverflow/current && bin/rails runner '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1' # noqa 204
+      "/bin/bash -l -c 'cd {{ current_path }} && bin/rails runner '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1'" # noqa 204
 
 - include_role:
     name: vendor/coopdevs.certbot_nginx

--- a/roles/webserver/templates/unicorn_service.j2
+++ b/roles/webserver/templates/unicorn_service.j2
@@ -5,11 +5,11 @@ Description=Timeoverflow unicorn server
 Type=simple
 SyslogIdentifier=timeoverflow-unicorn
 User=timeoverflow
-PIDFile=/var/www/timeoverflow/shared/tmp/pids/unicorn.pid
-WorkingDirectory=/var/www/timeoverflow/current
+PIDFile={{ app_path }}/shared/tmp/pids/unicorn.pid
+WorkingDirectory={{ current_path }}
 EnvironmentFile=-/etc/default/timeoverflow
 
-ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec /var/www/timeoverflow/current/bin/unicorn_rails -c /var/www/timeoverflow/current/config/unicorn.rb
+ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec {{ current_path }}/bin/unicorn_rails -c {{ current_path }}/config/unicorn.rb
 ExecReload=/bin/kill -s USR2 $MAINPID
 ExecStop=/bin/kill -s QUIT $MAINPID
 


### PR DESCRIPTION
This makes the code a bit easier to understand as well. You know at
a glance which things refer to the current release.

Note that we also removed the creation of `/var/www`. According to the
docs there is no need for that middle step

> If directory, all intermediate subdirectories will be created if they do not exist.

We can create the whole app_path in one shot.