### PR TITLE
Fix typo in backups config

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -9,4 +9,4 @@ app_path: "/var/www/timeoverflow"
 backups_role_postgresql_enabled: true
 backups_role_sudoers_enabled: true
 backups_role_db_names: ["{{ database_name }}"]
-backups_role_assets_path: "{{ app_path }}"
+backups_role_assets_paths: "{{ app_path }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,4 +13,4 @@
 - src: geerlingguy.redis
   version: 1.6.0
 - src: coopdevs.backups_role
-  version: v1.2.3
+  version: v1.2.4


### PR DESCRIPTION
This leads to a backup script with:

```
title "Compress assets data"
sudo tar -czvf /opt/backup/.tmp/assets.tar.gz
```

which then causes:

```
Tue Dec  3 18:04:02 CET 2019
tar: Cowardly refusing to create an empty archive
Try 'tar --help' or 'tar --usage' for more information.
```