### PR TITLE
Stop Sidekiq so the database restore can proceed

### DIFF
--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -29,6 +29,13 @@
         name: timeoverflow
         state: stopped
 
+    - name: Stop background job workers to kill database connections
+      become: yes
+      become_user: root
+      service:
+        name: sidekiq
+        state: stopped
+
     - pause: # noqa 502
         prompt: "\n   => ⚡ Warning, harmful action ahead. Are you sure you want to drop the target database `{{ database_name }}`? (yes/no)"
       register: drop_confirmation
@@ -71,4 +78,11 @@
       become_user: root
       service:
         name: timeoverflow
+        state: started
+
+    - name: Start background job workers
+      become: yes
+      become_user: root
+      service:
+        name: sidekiq
         state: started


### PR DESCRIPTION
Otherwise, PostgreSQL complaints about 2 sessions

```
fatal: [next.timeoverflow.org]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ca_cert": null,
            "conn_limit": "",
            "db": "timeoverflow_production",
            "encoding": "",
            "lc_collate": "",
            "lc_ctype": "",
            "login_host": "",
            "login_password": "",
            "login_unix_socket": "",
            "login_user": "postgres",
            "maintenance_db": "postgres",
            "name": "timeoverflow_production",
            "owner": "",
            "port": 5432,
            "session_role": null,
            "ssl_mode": "prefer",
            "state": "absent",
            "target": "",
            "target_opts": "",
            "template": ""
        }
    },
    "msg": "Database query failed: database \"timeoverflow_production\" is being accessed by other users\nDETAIL:  There are 2 other sessions using the database.\n"
}
```