### PR TITLE
Remove no longer accessible old production server

### DIFF
--- a/inventory/host_vars/www.timeoverflow.org/database_migration.yml
+++ b/inventory/host_vars/www.timeoverflow.org/database_migration.yml
@@ -1,4 +1,0 @@
----
-# Database migration settings
-source_db: timeoverflow_production
-ansible_python_interpreter: /usr/bin/python

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -7,15 +7,11 @@ staging.timeoverflow.org ansible_host=116.203.113.233
 [next]
 next.timeoverflow.org ansible_host=78.47.225.84
 
-[old_production]
-www.timeoverflow.org
-
 [timeoverflow:children]
 dev
 staging
 next
 ci
-old_production
 
 [ci]
 ci_server ansible_host=78.46.195.94


### PR DESCRIPTION
Nginx is stopped so there's no point in having the inventory host around. Besides, since there's no DNS record pointing to it, we don't know if things will work.