### PR TITLE
Provision production when release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,7 @@ jobs:
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=staging --vault-password-file=vault_pass
     - stage: provision_production
       script:
-        - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv -in encrypted_files.tar.enc -out encrypted_files.tar -d
-        - tar xvf encrypted_files.tar
-        - eval "$(ssh-agent -s)"
-        - chmod 600 travis
-        - ssh-add travis
-        - ansible-galaxy install -r requirements.yml
-        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=next --vault-password-file=vault_pass
-        - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=next --vault-password-file=vault_pass
+        - echo "Release $tag"
 stages:
   - name: provision_ci
     if: branch != master

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - ansible-galaxy install -r requirements.yml
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/sys_admins.yml --limit=staging --vault-password-file=vault_pass
         - ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook playbooks/provision.yml --limit=staging --vault-password-file=vault_pass
-    - stage: provision_next
+    - stage: provision_production
       script:
         - openssl aes-256-cbc -K $encrypted_8208c68d3911_key -iv $encrypted_8208c68d3911_iv -in encrypted_files.tar.enc -out encrypted_files.tar -d
         - tar xvf encrypted_files.tar
@@ -49,5 +49,5 @@ stages:
     if: branch != master
   - name: provision_staging
     if: type = push AND branch = master
-  - name: provision_next
-    if: type = push AND branch = master
+  - name: provision_production
+    if: type = push AND tag =~ ^v AND branch = master


### PR DESCRIPTION
This way we keep the automatic provisioning from CI, which provided invaluable the last few weeks.

This sets the ground for a release process. Tag the commit of the release and it'll end up in production :ok_hand:.

Then, when we confirm this works we can revert the last commit.