### PR TITLE
Fix multidomain cert with NGINX

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -12,3 +12,11 @@ backups_role_postgresql_enabled: true
 backups_role_sudoers_enabled: true
 backups_role_db_names: ["{{ database_name }}"]
 backups_role_assets_paths: ["{{ app_path }}"]
+
+nginx_sites:
+  timeoverflow:
+    template: timeoverflow.conf.j2
+    server_name: "{{ inventory_hostname }}"
+  timeoverflow_http:
+    template: timeoverflow_http.conf.j2
+    server_name: "{{ inventory_hostname }}"

--- a/inventory/host_vars/next.timeoverflow.org/config.yml
+++ b/inventory/host_vars/next.timeoverflow.org/config.yml
@@ -42,3 +42,17 @@ certificate_domain_names:
 
 # Enable backups
 backups_role_enabled: true
+
+nginx_sites:
+  timeoverflow:
+    template: timeoverflow.conf.j2
+    server_name: "{{ inventory_hostname }}"
+  timeoverflow_http:
+    template: timeoverflow_http.conf.j2
+    server_name: "{{ inventory_hostname }}"
+  timeoverflow_www:
+    template: timeoverflow.conf.j2
+    server_name: "www.timeoverflow.org"
+  timeoverflow_www_http:
+    template: timeoverflow_http.conf.j2
+    server_name: "www.timeoverflow.org"

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -30,6 +30,7 @@
       tags: es
     - role: webserver
       when: not development_environment
+      tags: webserver
     - role: cacheserver
     - role: geerlingguy.redis
     - role: background_jobs

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -33,10 +33,3 @@
     nginx_configs:
       upstream:
         - upstream app_server { server localhost:8080 fail_timeout=0; }
-    nginx_sites:
-      timeoverflow:
-        template: timeoverflow.conf.j2
-        server_name: "{{ inventory_hostname }}"
-      timeoverflow_http:
-        template: timeoverflow_http.conf.j2
-        server_name: "{{ inventory_hostname }}"


### PR DESCRIPTION
We have two domains pointing to the TO production instance: `next.timeoverflow.org` and `www.timeoverflow.org`. 
We need manage the two domains and the two certificates.

Creating one NGINX site per domain we can maintain the single domain certificates already created.

Also fixes the issue with the `www.timeoverflow.org` certificate.
The NGINX always served the `next.timeoverflow.org` certificate. Now, any site serve the correct cert.