### PR TITLE
Remove old Nginx site and cert

### DIFF
--- a/inventory/host_vars/timeoverflow.org/config.yml
+++ b/inventory/host_vars/timeoverflow.org/config.yml
@@ -37,16 +37,12 @@ superadmins: 'sseerrggii@gmail.com'
 # Let's Encrypt conf
 certificate_authority_email: "info@coopdevs.org"
 certificate_domain_names:
-  - "{{ inventory_hostname }}"
   - "www.timeoverflow.org"
 
 # Enable backups
 backups_role_enabled: true
 
 nginx_sites:
-  timeoverflow:
-    template: timeoverflow.conf.j2
-    server_name: "{{ inventory_hostname }}"
   timeoverflow_http:
     template: timeoverflow_http.conf.j2
     server_name: "{{ inventory_hostname }}"

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -15,6 +15,11 @@
     job: >
       "/bin/bash -l -c 'cd {{ current_path }} && bin/rails runner '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1'" # noqa 204
 
+- name: Remove old timeoverflow.conf nginx site
+  file:
+    state: absent
+    path: /etc/nginx/sites-enabled/timeoverflow.conf
+
 - include_role:
     name: vendor/coopdevs.certbot_nginx
 


### PR DESCRIPTION
We are serving traffic from www.timeoverflow.org and timeoverflow.org only redirects to it. It is a "redirección web" from CDmon itself, the domain provider.

Without this, Nginx fails to create the certificate since the cert's domain and the site's server_name don't match.

Another consequence was the following failure:

```
RUNNING HANDLER [jdauphant.nginx : check nginx configuration] *************************************************************************************************************************
fatal: [timeoverflow.org]: FAILED! => {"changed": true, "cmd": ["nginx", "-t", "-c", "/etc/nginx/nginx.conf"], "delta": "0:00:00.027624", "end": "2020-01-22 10:50:42.929312", "msg": "
non-zero return code", "rc": 1, "start": "2020-01-22 10:50:42.901688", "stderr": "nginx: [emerg] BIO_new_file(\"/etc/letsencrypt/live/timeoverflow.org/fullchain.pem\") failed (SSL: er
ror:02001002:system library:fopen:No such file or directory:fopen('/etc/letsencrypt/live/timeoverflow.org/fullchain.pem','r') error:2006D080:BIO routines:BIO_new_file:no such file)\nn
ginx: configuration file /etc/nginx/nginx.conf test failed", "stderr_lines": ["nginx: [emerg] BIO_new_file(\"/etc/letsencrypt/live/timeoverflow.org/fullchain.pem\") failed (SSL: error
:02001002:system library:fopen:No such file or directory:fopen('/etc/letsencrypt/live/timeoverflow.org/fullchain.pem','r') error:2006D080:BIO routines:BIO_new_file:no such file)", "ng
inx: configuration file /etc/nginx/nginx.conf test failed"], "stdout": "", "stdout_lines": []}
```

The `timeoverflow.org` couldn't then find its matching cert file.

So, from now on, an Nginx site serves from `server_name: www.timeoverflow.org` and references the `www.timeoverflow.org` cert file :ok_hand:.