### PR TITLE
Remove old next.timeoverflow.org nginx site

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -15,11 +15,6 @@
     job: >
       "/bin/bash -l -c 'cd {{ current_path }} && bin/rails runner '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1'" # noqa 204
 
-- name: Remove old timeoverflow.conf nginx site
-  file:
-    state: absent
-    path: /etc/nginx/sites-enabled/timeoverflow.conf
-
 - include_role:
     name: vendor/coopdevs.certbot_nginx
 
@@ -31,6 +26,16 @@
   with_items: "{{ certificate_domain_names }}"
   loop_control:
     loop_var: domain_name
+
+- name: Remove old timeoverflow.conf nginx site
+  file:
+    state: absent
+    path: /etc/nginx/sites-enabled/timeoverflow.conf
+
+- name: Remove old next.timeoverflow.conf nginx site
+  file:
+    state: absent
+    path: /etc/nginx/sites-enabled/next.timeoverflow.org
 
 - include_role:
     name: vendor/jdauphant.nginx


### PR DESCRIPTION
We first removed its DNS record. Then, I manually revoked and removed
its SSL certificate as follows

```
pau@timeoverflow-production:~$ sudo certbot revoke --cert-name=next.timeoverflow.org
Saving debug log to /var/log/letsencrypt/letsencrypt.log

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Would you like to delete the cert(s) you just revoked, along with all earlier
and later versions of the cert?
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
(Y)es (recommended)/(N)o: Y

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Deleted all files relating to certificate next.timeoverflow.org.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Congratulations! You have successfully revoked the certificate that was located
at /etc/letsencrypt/live/next.timeoverflow.org/fullchain.pem

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

pau@timeoverflow-production:~$ sudo certbot certificates
Saving debug log to /var/log/letsencrypt/letsencrypt.log

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Found the following certs:
  Certificate Name: www.timeoverflow.org
  Domains: www.timeoverflow.org
  Expiry Date: 2020-03-03 14:04:11+00:00 (VALID: 40 days)
  Certificate Path: /etc/letsencrypt/live/www.timeoverflow.org/fullchain.pem
  Private Key Path: /etc/letsencrypt/live/www.timeoverflow.org/privkey.pem
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```

I couldn't find a way to do that programmatically from Ansible. How do
manage an interactive prompt from Ansible if certbot doesn't provide the
corresponding command line arguments?

Finally, we can get rid of the Nginx site as no HTTP requests are received.