### PR TITLE
Use FQDN as action_mailer's host

### DIFF
--- a/roles/common/templates/default.j2
+++ b/roles/common/templates/default.j2
@@ -3,7 +3,7 @@ DATABASE_NAME={{ database_name }}
 DATABASE_USER={{ database_user }}
 DATABASE_PASSWORD={{ database_password }}
 SECRET_TOKEN={{ secret_token }}
-MAIL_LINK_HOST={{ inventory_hostname }}
+MAIL_LINK_HOST=www.timeoverflow.org
 MAILER_SENDER={{ mailer_sender }}
 {% if skylight_authentication is defined %}
 SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}


### PR DESCRIPTION
Having `MAIL_LINK_HOST=timeoverflow.org` we get the following error

```
ActionView::Template::Error (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):
    2:
    3: <p>S'ha sol·licitat el canvi de la teva contrasenya. Pots canviar-la a travès del següent enllaç.</p>
    4:
    5: <p><%= link_to 'Canviar contrasenya', edit_password_url(@resource, :reset_password_token => @token) %></p>
    6:
    7: <p>Si tu no has sol·licitat el canvi de contrasenya, no facis cas d'aquest correu.</p>
    8: <p>La teva contrasenya no canviarà fins que no facis clic a l'enllaç.</p>
  app/views/devise/mailer/reset_password_instructions.ca.html.erb:5:in `_app_views_devise_mailer_reset_password_instructions_ca_html_erb___1372667663275105320_47227158859440'
```

`default_url_options` is `config.action_mailer` setter.