### PR TITLE
Remove crontab entry for email digest

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -8,12 +8,7 @@
   cron:
     name: send_recent_posts_to_online_members
     user: "{{ app_user }}"
-    weekday: 1
-    hour: 9
-    minute: 0
-    state: present
-    job: >
-      "/bin/bash -l -c 'cd {{ current_path }} && bin/rails runner '\''OrganizationNotifierService.new(Organization.all).send_recent_posts_to_online_members'\'' >> log/cron_log.log 2>&1'" # noqa 204
+    state: absent
 
 - include_role:
     name: vendor/coopdevs.certbot_nginx


### PR DESCRIPTION
Since https://github.com/coopdevs/timeoverflow/pull/401 it's managed by sidekiq-cron, like we already do with push notifications.