### PR TITLE
Remove memcached

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -13,7 +13,6 @@
           - nginx
           - certbot
           - python-certbot-nginx
-          - memcached
     - role: common
     - role: vendor/zzet.rbenv
       rbenv:

--- a/roles/cacheserver/tasks/main.yml
+++ b/roles/cacheserver/tasks/main.yml
@@ -2,10 +2,6 @@
 - name: Install memcached
   apt:
     name: memcached
-    state: present
-
-- name: Start memcached service
-  service:
-    name: memcached
-    enabled: yes
-    state: started
+    state: absent
+    purge=yes
+    force=yes

--- a/roles/cacheserver/tasks/main.yml
+++ b/roles/cacheserver/tasks/main.yml
@@ -3,5 +3,5 @@
   apt:
     name: memcached
     state: absent
-    purge=yes
-    force=yes
+    purge: yes
+    force: yes


### PR DESCRIPTION
I modified the cacheserver role to uninstall memcached when executed, also removed memcached from the list of autoupdate packages.

Moreover, I realized that my ssh key had a little mistake and deleted it.

Now, this role removes memcached when it's installed and don't install it if it's not.

Fix #144 