### PR TITLE
Remove absent state tasks nginx

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -27,16 +27,6 @@
   loop_control:
     loop_var: domain_name
 
-- name: Remove old timeoverflow.conf nginx site
-  file:
-    state: absent
-    path: /etc/nginx/sites-enabled/timeoverflow.conf
-
-- name: Remove old next.timeoverflow.conf nginx site
-  file:
-    state: absent
-    path: /etc/nginx/sites-enabled/next.timeoverflow.org
-
 - include_role:
     name: vendor/jdauphant.nginx
   vars:


### PR DESCRIPTION
I removed "Remove old timeoverflow.conf nginx site" and "Remove old next.timeoverflow.conf nginx site" from webserver role, which were supposed to remove the follow paths:
`/etc/nginx/sites-enabled/timeoverflow.conf`
`/etc/nginx/sites-enabled/next.timeoverflow.org`

When I checked on staging, `timeoverflow.conf` was there, not removed. And this is what there are on production: 
`timeoverflow_http.conf` 
`timeoverflow_www.conf`
`timeoverflow_www_http.conf`

Fix #161 