### PR TITLE
Remove memcached totally

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -30,7 +30,6 @@
     - role: webserver
       when: not development_environment
       tags: webserver
-    - role: cacheserver
     - role: geerlingguy.redis
     - role: background_jobs
     - role: coopdevs.backups_role

--- a/roles/cacheserver/tasks/main.yml
+++ b/roles/cacheserver/tasks/main.yml
@@ -1,7 +1,0 @@
----
-- name: Install memcached
-  apt:
-    name: memcached
-    state: absent
-    purge: yes
-    force: yes


### PR DESCRIPTION
I removed the cacheserver role, which was used to uninstall memcached and the call to that role on the playbook.

Memcached is gone now :tada: 