### PR TITLE
Switch order ci stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 
 jobs:
   include:
+  #linters 
     - stage: lint
       script: ansible-lint playbooks/*.yml
       script: yamllint **/*.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
   include:
     - stage: lint
       script: ansible-lint playbooks/*.yml
-    - stage: lint
       script: yamllint **/*.yml
     - stage: provision_ci
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache:
 
 jobs:
   include:
-  #linters 
     - stage: lint
       script: ansible-lint playbooks/*.yml
+    -
       script: yamllint **/*.yml
     - stage: provision_ci
       script:
@@ -38,6 +38,7 @@ jobs:
       script:
         - echo "Release $tag"
 stages:
+  - lint
   - name: provision_ci
     if: branch != master
   - name: provision_staging


### PR DESCRIPTION
Lint was happening after provisioning, in order to change it I have added `lint` stage to `stages` before provision stages and removed the repeated name on `jobs`.

Now it runs first the two lint scripts and then the right provision.

![lint_pantallazo](https://user-images.githubusercontent.com/55448468/80471248-73647900-8943-11ea-8e61-d30aef9f35ce.png)

On the picture, the second stage fails because it is on my fork and I don't have some necessary keys to decrypt some files.


Fix #117 