### PR TITLE
Fix EnvironmentFile systemd directive

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -7,7 +7,7 @@ database_user: timeoverflow
 app_path: "/var/www/timeoverflow"
 current_path: "{{ app_path }}/current"
 app_user: "timeoverflow"
-environment_file: "etc/default/timeoverflow"
+environment_file: "/etc/default/timeoverflow"
 
 # Backups vars
 backups_role_postgresql_enabled: true

--- a/roles/background_jobs/templates/sidekiq_service.j2
+++ b/roles/background_jobs/templates/sidekiq_service.j2
@@ -9,7 +9,7 @@ After=syslog.target network.target redis_6379.service
 [Service]
 Type=simple
 WorkingDirectory={{ current_path }}
-EnvironmentFile=-{{ environment_file }}
+EnvironmentFile={{ environment_file }}
 ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec sidekiq -e {{ rails_environment }}
 User={{ app_user }}
 Group=timeoverflow

--- a/roles/webserver/templates/unicorn_service.j2
+++ b/roles/webserver/templates/unicorn_service.j2
@@ -7,7 +7,7 @@ SyslogIdentifier=timeoverflow-unicorn
 User={{ app_user }}
 PIDFile={{ app_path }}/shared/tmp/pids/unicorn.pid
 WorkingDirectory={{ current_path }}
-EnvironmentFile=-{{ environment_file }}
+EnvironmentFile={{ environment_file }}
 
 ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec {{ current_path }}/bin/unicorn_rails -c {{ current_path }}/config/unicorn.rb
 ExecReload=/bin/kill -s USR2 $MAINPID


### PR DESCRIPTION
We broke the path to the user defaults in https://github.com/coopdevs/timeoverflow-provisioning/pull/150.

We also discovered the meaning of that `-`:

> The "-" on the EnvironmentFile= line ensures that no error messages is
generated if the environment file does not exist. Since many of these
files were optional in sysvinit, you should include the "-" when using
this directive.

sources:
https://fedoraproject.org/wiki/Packaging:Systemd#EnvironmentFiles_and_support_for_.2Fetc.2Fsysconfig_files, https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=

We don't want that dash. If the file is not found we want to know, not to fail silently. The env vars it contains are nowhere else.

And it turns out this also fixes Monday's digest email.