### PR TITLE
Fix production backups

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -13,7 +13,7 @@ environment_file: "/etc/default/timeoverflow"
 backups_role_postgresql_enabled: true
 backups_role_sudoers_enabled: true
 backups_role_db_names: ["{{ database_name }}"]
-backups_role_assets_paths: ["{{ app_path }}"]
+backups_role_assets_paths: ["{{ current_path }}/public"]
 
 nginx_sites:
   timeoverflow:

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -34,3 +34,4 @@
     - role: background_jobs
     - role: coopdevs.backups_role
       when: backups_role_enabled
+      tags: backups


### PR DESCRIPTION
We are having a bunch of issues when performing the backup such as tar not licking socket files or files being changed while reading them. 

A solution is to back up only assets as they are what could go lost if there's a serious issue with the server. The app code is stored in the Github repo so to recover from a failure we would deploy again, restore the assets from the backup and the DB from the dump.

Backing up anything else beyond public/ is becoming tricky. Log files change while issuing the tar command (it doesn't like that) and I'm struggling trying to exclude the log/ and tmp/ directories. This way things are way simpler.