### PR TITLE
Enable unaccent PostgreSQL extension

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -25,6 +25,7 @@
         - timeoverflow
       default_gems_file: ../files/custom-gems
     - role: database
+      tags: db
     - role: elasticsearch
       tags: es
     - role: webserver

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -59,3 +59,10 @@
   postgresql_ext:
     name: hstore
     db: "{{ database_name }}"
+
+- name: Add unaccent extension to the database
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: unaccent
+    db: "{{ database_name }}"


### PR DESCRIPTION
The `CREATE EXTENSION` statement requires SUPERUSER privileges and although there's a Rails migration enabling that one, it feels safer not to grant this privilege to the app user and enable it at provisioning-time.
    
After this, since it's already enabled, the migration succeeds.