### PR TITLE
Update bundler to 2.1.4

### DIFF
--- a/files/custom-gems
+++ b/files/custom-gems
@@ -1,1 +1,1 @@
-bundler 1.17.0
+bundler 2.1.4


### PR DESCRIPTION
This only install the required bundler version when installing a new Ruby version. It does not do that when Ruby is unchanged. To solve this I did a `gem install bundler -v 2.1.4` manually. All prior efforts using the command module failed so I figured it wasn't a big deal since it's a change that happens very rarely.

This is bundler version is the one Gemfile.lock at coopdevs/timeoverflow#516 defines.