### PR TITLE
Boot Unicorn using bundle exec instead of binstub

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -3,6 +3,12 @@
   template:
     src: unicorn_service.j2
     dest: /etc/systemd/system/timeoverflow.service
+  register: timeoverflow_unit
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+  when: timeoverflow_unit.changed
 
 - name: Create crontab entries for scheduled job
   cron:

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -5,7 +5,7 @@
     dest: /etc/systemd/system/timeoverflow.service
   register: timeoverflow_unit
 
-- name: Reload systemd
+- name: Reload systemd # noqa 503
   systemd:
     daemon_reload: yes
   when: timeoverflow_unit.changed

--- a/roles/webserver/templates/unicorn_service.j2
+++ b/roles/webserver/templates/unicorn_service.j2
@@ -9,7 +9,7 @@ PIDFile={{ app_path }}/shared/tmp/pids/unicorn.pid
 WorkingDirectory={{ current_path }}
 EnvironmentFile={{ environment_file }}
 
-ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec {{ current_path }}/bin/unicorn_rails -c {{ current_path }}/config/unicorn.rb
+ExecStart=/home/timeoverflow/.rbenv/bin/rbenv exec bundle exec unicorn -c config/unicorn.rb
 ExecReload=/bin/kill -s USR2 $MAINPID
 ExecStop=/bin/kill -s QUIT $MAINPID
 


### PR DESCRIPTION
Fixes #184 

We removed bin/unicorn and bin/unicorn_rails in https://github.com/coopdevs/timeoverflow/commit/29c8ec03fc5aef28fb59ca2e24ba49345a4c368d,
which was used to start the systemd unit. Those binstubs don't add much and we can simply use `bundle exec`. We also make use of the `WorkingDirectory` directive and avoid full paths for better readability.

Also, it looks like we introduced Unicorn back in https://github.com/coopdevs/timeoverflow/commit/b8fc45aad80fbda06d2b83dd70da15e776c6bdb2
but never really added the gem https://github.com/samuelkadolph/unicorn-rails for which we did add a binstub. Perhaps the change in the Gemfile was never committed?