### PR TITLE
change host url

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -5,7 +5,7 @@ timeoverflow.local
 staging.timeoverflow.org ansible_host=116.203.113.233
 
 [production]
-timeoverflow.org ansible_host=78.47.225.84
+www.timeoverflow.org ansible_host=78.47.225.84
 
 [old_production]
 www.timeoverflow.org ansible_host=78.47.218.98


### PR DESCRIPTION
Because of the last PR https://github.com/coopdevs/timeoverflow-provisioning/pull/197 and the fact that we don't redirect form non www to www https://github.com/coopdevs/timeoverflow-provisioning/issues/199  the mails send links to timeoverflow.org and will not response

With this change we will have the correct hostname
