### PR TITLE
Configure logrotate for the timeoverflow app logs

### DIFF
--- a/inventory/host_vars/www.timeoverflow.org/config.yml
+++ b/inventory/host_vars/www.timeoverflow.org/config.yml
@@ -180,3 +180,12 @@ aws_bucket: timeoverflow-production
 aws_region: eu-west-3
 
 nginx_max_body_size: 15M
+
+logrotate_conf: |
+      /var/www/timeoverflow/current/log/*.log {
+             weekly
+             rotate 20
+             size 300M
+             compress
+             delaycompress
+      }

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -33,6 +33,8 @@
       tags: webserver
     - role: geerlingguy.redis
     - role: background_jobs
+    - role: logrotate
+      tags: logrotate
     - role: coopdevs.backups_role
       when: backups_role_enabled
       tags: backups

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure logrotate
+  blockinfile:
+    path: /etc/logrotate.d/timeoverflow
+    block: "{{ logrotate_conf }}"
+    create: true


### PR DESCRIPTION
We configure logrotate to avoid disk problems. 